### PR TITLE
Docs/add more initial instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,27 @@ git clone https://github.com/dansenpir/owlrangenotes-mobile
 cd owlrangenotes-mobile && yarn install
 ```
 
-3. Inicie as dependências mobile e instale o app
+3. Crie uma chave de assinatura para buildar o app
+No passo a seguir, você criará uma keystore (chave de assinatura) no ```android/app/```
+```bash
+cd android/app &&
+keytool -genkey -v -keystore debug.keystore -storepass android -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 &&
+cd ../..
+```
+> Você pode preencher o formulário ou apenas ir apertando enter e depois yes
+
+
+4. Inicie as dependências mobile e instale o app
 Neste passo, você estará iniciando as dependências do mobile, no caso os arquivos nas pastas  ```ios/``` e/ou ```android/``` serão criadas. Este processo é feito apenas uma vez.
 Este mesmo comando é responsável por buildar uma versão do app de desenvolvimento em seu emulador ou dispositivo conectado ao USB [(Configurar o ADB talvez seja necessário)](https://reactnative.dev/docs/running-on-device).
 
+> Certifique-se de estar na raíz do projeto (owlrangenotes-mobile/)
 ```bash
 yarn android
 yarn ios # Somente se estiver em um macOS.
 ```
 
-4. Suba o Metro (server bundler):
+5. Suba o Metro (server bundler):
 ```bash
 yarn start
 ```

--- a/README.md
+++ b/README.md
@@ -10,50 +10,48 @@ Com esse aplicativo, o problema acaba. 😍
 
 ## Stack utilizada
 
-React Native, TypeScript, Styled Components, Moti, Lottie e React Navigation.
+- React Native e TypeScript;
+- React Navigation;
+- Styled Components;
+- Lottie;
+- Moti.
 
 ## Rodando localmente
 
 > Nesse projeto é usado apenas o Yarn como gerenciador de pacotes. Recomendamos que faça o mesmo, prevenindo eventuais problemas. Veja o website oficial do Yarn [aqui](https://yarnpkg.com/).
 
-Clone o projeto
 
+### Rodando o app
+>Para continuar, requer que tenha já feito as instalações em sua máquina referente a JDK11 e as SDKs (android). Caso não, você pode seguir a [documentação oficial do React Native](https://reactnative.dev/docs/environment-setup) ou a da [Rocketseat](https://react-native.rocketseat.dev/) a qual está em português.
+
+1. Clone o projeto
 ```bash
-  git clone https://github.com/dansenpir/owlrangenotes-mobile
+git clone https://github.com/dansenpir/owlrangenotes-mobile
 ```
 
-Entre no diretório do projeto
-
+2. Entre no diretório do projeto e instale as dependências
 ```bash
-  cd owlrangenotes-mobile
+cd owlrangenotes-mobile && yarn install
 ```
 
-Instale as dependências
+3. Inicie as dependências mobile e instale o app
+Neste passo, você estará iniciando as dependências do mobile, no caso os arquivos nas pastas  ```ios/``` e/ou ```android/``` serão criadas. Este processo é feito apenas uma vez.
+Este mesmo comando é responsável por buildar uma versão do app de desenvolvimento em seu emulador ou dispositivo conectado ao USB [(Configurar o ADB talvez seja necessário)](https://reactnative.dev/docs/running-on-device).
 
 ```bash
-  yarn install
+yarn android
+yarn ios # Somente se estiver em um macOS.
 ```
 
-Rodar o React Native - Android e IOS
-
+4. Suba o Metro (server bundler):
 ```bash
-  yarn start
+yarn start
 ```
 
-Rodar o React Native - Android
+Com estes passos, você estará com o app instalado.
 
-```bash
-  yarn run android
-```
-
-Rodar o React Native - IOS
-
-```bash
-  yarn run ios
-```
-
+### Adicionais
 Rodar testes (Jest)
-
 ```bash
   yarn test
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/) 
+[![GPLv3 License](https://img.shields.io/badge/License-GPL%20v3-yellow.svg)](https://opensource.org/licenses/)
 
 # Owlrange Mobile 📱
 
@@ -22,7 +22,7 @@ Com esse aplicativo, o problema acaba. 😍
 
 
 ### Rodando o app
->Para continuar, requer que tenha já feito as instalações em sua máquina referente a JDK11 e as SDKs (android). Caso não, você pode seguir a [documentação oficial do React Native](https://reactnative.dev/docs/environment-setup) ou a da [Rocketseat](https://react-native.rocketseat.dev/) a qual está em português.
+>Para continuar, requer que tenha já feito as instalações em sua máquina referente a JDK11 e as SDKs (Android). Caso não, você pode seguir a [documentação oficial do React Native](https://reactnative.dev/docs/environment-setup) ou a da [Rocketseat](https://react-native.rocketseat.dev/) a qual está em português.
 
 1. Clone o projeto
 ```bash
@@ -31,7 +31,7 @@ git clone https://github.com/dansenpir/owlrangenotes-mobile
 
 2. Entre no diretório do projeto e instale as dependências
 ```bash
-cd owlrangenotes-mobile && yarn install
+cd owlrangenotes-mobile && yarn
 ```
 
 3. Crie uma chave de assinatura para buildar o app


### PR DESCRIPTION
![Screenshot_2022-10-18_20-37-34](https://user-images.githubusercontent.com/17092357/196575430-ce3cee00-5e4d-4bbe-a333-faec8b3798a5.png)

Este PR propõe a dar um "fix" em um "espaçamento" ao copiar os comandos do bash. Nada que prejudicasse, apenas pelo ~toc~ padrão.
Também adiciona mais instruções a instalação.